### PR TITLE
Payment method setup

### DIFF
--- a/app/models/solidus_bolt.rb
+++ b/app/models/solidus_bolt.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  def self.table_name_prefix
+    'solidus_bolt_'
+  end
+end

--- a/app/models/solidus_bolt/bolt_checkout.rb
+++ b/app/models/solidus_bolt/bolt_checkout.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  class BoltCheckout < SolidusSupport.payment_method_parent_class
+    preference :bolt_api_key, :string
+    preference :bolt_signing_secret, :string
+
+    def gateway_class
+      ::SolidusBolt::Gateway
+    end
+
+    def payment_source_class
+      ::SolidusBolt::PaymentSource
+    end
+
+    def partial_name
+      'bolt'
+    end
+  end
+end

--- a/lib/solidus_bolt/configuration.rb
+++ b/lib/solidus_bolt/configuration.rb
@@ -2,9 +2,7 @@
 
 module SolidusBolt
   class Configuration
-    # Define here the settings for this extension, e.g.:
-    #
-    # attr_accessor :my_setting
+    attr_accessor :bolt_api_key, :bolt_signing_secret
   end
 
   class << self

--- a/lib/solidus_bolt/engine.rb
+++ b/lib/solidus_bolt/engine.rb
@@ -11,6 +11,17 @@ module SolidusBolt
 
     engine_name 'solidus_bolt'
 
+    initializer "solidus_bolt.add_static_preference", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << SolidusBolt::BoltCheckout
+      Spree::Config.static_model_preferences.add(
+        SolidusBolt::BoltCheckout,
+        'bolt_credentials', {
+          bolt_api_key: ENV['BOLT_API_KEY'],
+          bolt_signing_secret: ENV['BOLT_SIGNING_SECRET']
+        }
+      )
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec

--- a/spec/models/solidus_bolt/bolt_checkout_spec.rb
+++ b/spec/models/solidus_bolt/bolt_checkout_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::BoltCheckout, type: :model do
+  describe '#gateway_class' do
+    it 'has correct gateway class' do
+      expect(described_class.new.gateway_class).to eq SolidusBolt::Gateway
+    end
+  end
+
+  describe '#payment_source_class' do
+    it 'has correct payment_source class' do
+      expect(described_class.new.payment_source_class).to eq SolidusBolt::PaymentSource
+    end
+  end
+
+  describe '#partial_name' do
+    it 'has correct partial name' do
+      expect(described_class.new.partial_name).to eq 'bolt'
+    end
+  end
+end


### PR DESCRIPTION
This PR setups the Bolt Checkout Payment Method

The Payment Method is named `BoltCheckout`.
This commit also adds the `bolt_api_key` and the `bolt_signing_secret` to the credentials for the payment method.

#3 