### PR TITLE
Capture payment via Gateway

### DIFF
--- a/spec/models/solidus_bolt/gateway_spec.rb
+++ b/spec/models/solidus_bolt/gateway_spec.rb
@@ -1,13 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe SolidusBolt::Gateway, type: :model do
+  let(:order) { create(:order_with_line_items) }
+  let(:amount) { (order.total * 100).to_i }
+  let(:payment_method) { create(:bolt_payment_method) }
+  let(:payment_source) { create(:bolt_payment_source, payment_method: payment_method) }
+  let(:payment) {
+    create(:payment, order: order, source_id: payment_source.id, source_type: SolidusBolt::PaymentSource,
+      payment_method: payment_method)
+  }
+  let(:gateway_options) {
+    {
+      order_id: "#{order.number}-123456",
+      originator: payment
+    }
+  }
+
   describe '#authorize' do
     subject(:authorize) { described_class.new.authorize(nil, payment_source, gateway_options) }
 
-    let(:order) { create(:order_with_line_items) }
-    let(:gateway_options) { { order_id: "#{order.number}-123456" } }
-    let(:payment_method) { create(:bolt_payment_method) }
-    let(:payment_source) { create(:bolt_payment_source, payment_method: payment_method) }
     let(:response) { { 'transaction' => { 'reference' => 'fakereference' } } }
 
     before { allow(SolidusBolt::Transactions::AuthorizeService).to receive(:call).and_return(response) }
@@ -22,8 +33,23 @@ RSpec.describe SolidusBolt::Gateway, type: :model do
   end
 
   describe '#capture' do
-    it 'raises NotImplementedError' do
-      expect { described_class.new.capture(nil, nil, nil) }.to raise_error(NotImplementedError)
+    subject(:capture) { described_class.new.capture(amount, response_code, gateway_options) }
+
+    let(:response_code) { 'the_amazing_spiderman' }
+    let(:response) {
+      { 'reference' => response_code }
+    }
+
+    before do
+      allow(SolidusBolt::Transactions::CaptureService).to receive(:call).and_return(response)
+    end
+
+    it 'returns an active merchant billing response' do
+      expect(capture).to be_an_instance_of(ActiveMerchant::Billing::Response)
+    end
+
+    it 'stores the transaction reference as response code' do
+      expect(capture.authorization).to eq response_code
     end
   end
 


### PR DESCRIPTION
This PR implements the `capture` method in the Gateway for Bolt.

The capture method calls the `SolidusBolt::Transactions::CaptureService` to make the Bolt Capture API Call and stores the response reference for future steps.