### PR TITLE
Fix omniauth 2.0.6 compatibility

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -49,7 +49,12 @@ fi
 
 cd ./sandbox
 cat <<RUBY >> Gemfile
-gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
+gem "solidus_core", git: "https://github.com/solidusio/solidus.git", ref: '$BRANCH'
+gem "solidus_backend", git: "https://github.com/solidusio/solidus.git", ref: "$BRANCH"
+gem "solidus_api", git: "https://github.com/solidusio/solidus.git", ref: "$BRANCH"
+gem "solidus_sample", git: "https://github.com/solidusio/solidus.git", ref: "$BRANCH"
+gem "solidus_frontend", git: "https://github.com/solidusio/solidus_frontend.git", ref: "$BRANCH"
+
 gem 'solidus_auth_devise', '>= 2.1.0'
 gem 'rails-i18n'
 gem 'solidus_i18n'


### PR DESCRIPTION
solidus_social has been updated and upgrades omniauth from 1.9.6 to
2.0.6.
The OmniAuth::Builder middleware is not loaded anymore, this commit
adds a code to load it, and changes as the provider is defined.