### PR TITLE
Add billing_address to credit_card

### DIFF
--- a/app/models/solidus_bolt/gateway.rb
+++ b/app/models/solidus_bolt/gateway.rb
@@ -127,6 +127,10 @@ module SolidusBolt
         card_params[k.gsub('card_', '').to_sym] = v unless v.nil?
       end
 
+      card_params.merge!(
+        payment_source.payments.first.order.billing_address.bolt_address(payment_source.payments.first.order.email)
+      )
+
       card_params
     end
   end

--- a/spec/models/solidus_bolt/gateway_spec.rb
+++ b/spec/models/solidus_bolt/gateway_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe SolidusBolt::Gateway, type: :model do
       expect(payment_source.reload.card_id).to eq('1234')
     end
 
+    it 'receives the billing_address on the credit_card' do
+      authorize
+
+      expect(SolidusBolt::Transactions::AuthorizeService).to have_received(:call).with(
+        hash_including(credit_card: hash_including(:country_code, :email))
+      )
+    end
+
     it 'returns an active merchant billing response' do
       expect(authorize).to be_an_instance_of(ActiveMerchant::Billing::Response)
     end
@@ -117,6 +125,14 @@ RSpec.describe SolidusBolt::Gateway, type: :model do
     it 'updates the card_id of the payment_source' do
       purchase
       expect(payment_source.reload.card_id).to eq('1234')
+    end
+
+    it 'receives the billing_address on the credit_card' do
+      purchase
+
+      expect(SolidusBolt::Transactions::AuthorizeService).to have_received(:call).with(
+        hash_including(credit_card: hash_including(:country_code, :email))
+      )
     end
 
     it 'returns an active merchant billing response' do


### PR DESCRIPTION
This commit adds the billing addres to the credit_card info.

https://help.bolt.com/api-bolt/#tag/Transactions/operation/MerchantAuthorize