### PR TITLE
Rename default branch to main and update Solidus reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,14 @@ workflows:
       - run-specs-with-mysql
       - lint-code
 
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-solidus_git, solidus_frontend_git = if (branch == 'master') || (branch >= 'v3.2')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
+solidus_git, solidus_frontend_git = if (branch == 'main') || (branch >= 'v3.2')
                                       %w[solidusio/solidus solidusio/solidus_frontend]
                                     else
                                       %w[solidusio/solidus] * 2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solidus Bolt
 
 [![CircleCI](https://circleci.com/gh/solidusio/solidus_bolt.svg?style=shield)](https://circleci.com/gh/solidusio-contrib/solidus_bolt)
-[![codecov](https://codecov.io/gh/solidusio/solidus_bolt/branch/master/graph/badge.svg)](https://codecov.io/gh/solidusio-contrib/solidus_bolt)
+[![codecov](https://codecov.io/gh/solidusio/solidus_bolt/branch/main/graph/badge.svg)](https://codecov.io/gh/solidusio-contrib/solidus_bolt)
 
 <!-- Explain what your extension does. -->
 
@@ -36,7 +36,7 @@ Alternatively you can setup the Bolt Configuration manually by visiting `/admin/
 
 ### Using solidus_bolt Seeds
 
-Provided you setup the environment variables, you can simplify the setup of a Bolt application by running the [gem's seeds](https://github.com/nebulab/solidus_bolt/blob/master/db/seeds.rb). This will automatically create the following:
+Provided you setup the environment variables, you can simplify the setup of a Bolt application by running the [gem's seeds](https://github.com/solidusio/solidus_bolt/blob/main/db/seeds.rb). This will automatically create the following:
 
 - BoltConfiguration
 - AuthenticationMethod

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -22,7 +22,7 @@ if [ ! -z $SOLIDUS_BRANCH ]
 then
   BRANCH=$SOLIDUS_BRANCH
 else
-  BRANCH="master"
+  BRANCH="main"
 fi
 
 extension_name="solidus_bolt"

--- a/solidus_bolt.gemspec
+++ b/solidus_bolt.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.license = 'Apache-2.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/nebulab/solidus_bolt'
-  spec.metadata['changelog_uri'] = 'https://github.com/nebulab/solidus_bolt/blob/master/CHANGELOG.md'
+  spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_bolt'
+  spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_bolt/blob/main/CHANGELOG.md'
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 


### PR DESCRIPTION
## Summary

We update the default branch here to main, and Solidus already updated it in the past. We also reflect that we moved the extension to the solidusio organization.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
